### PR TITLE
Update the doc related to cli of golang to v2

### DIFF
--- a/docs/03_dev-guide/03-02-drand-client_CLI.md
+++ b/docs/03_dev-guide/03-02-drand-client_CLI.md
@@ -14,33 +14,19 @@ The `drand-client` command-line interface application can be used to fetch ran
 This will require a working [**Golang installation**](https://golang.org/doc/install). You'll also need the `make` command available.
 
 ```jsx
-git clone https://github.com/drand/drand
-cd drand
-make drand-client
-```
-
-## **From Docker**
-
-```jsx
-docker run drandorg/drand-client
+git clone https://github.com/drand/go-clients.git
+cd go-clients 
+make client-tool
 ```
 
 # **Usage**
 
-Run `drand-client --help` for a list of supported options. 
+Run `./drand-cli --help` for a list of supported options. 
 
 As an example, here is how to launch the client in order to read randomness for the current [League of Entropy](https://leagueofentropy.org) mainnet endpoints with automatic verification, failover and fastest-endpoint optimizations:
 
 ```jsx
-drand-client --watch \
---chain-hash 8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce \
---url http://api.drand.sh \
---url http://api2.drand.sh \
---url http://api3.drand.sh \
---url https://drand.cloudflare.com \
---relay /dnsaddr/api.drand.sh \
---relay /dnsaddr/api2.drand.sh \
---relay /dnsaddr/api3.drand.sh
+./drand-cli get chain-info --url https://api.drand.sh --insecure
 ```
 
 ---


### PR DESCRIPTION
Current doc is written for v1 instead of v2. This is to propose changes for v2. 