### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/02_concepts/02-00-Intro-to-drand.md
+++ b/docs/02_concepts/02-00-Intro-to-drand.md
@@ -5,12 +5,12 @@ description: A brief introduction to key concepts
 ---
 # 2.0 Intro to drand
 
-This section introduces the key concepts behind drand. For information about consuming randomness from a drand network, see the [**Developer's Guide**](../dev-guide/3-0-dev-guide). For help running a drand network, see the entries under the “For Operators” section. To run node(s) or relay(s) for the [League of Entropy](https://leagueofentropy.org), please [apply to the League](https://docs.google.com/forms/d/e/1FAIpQLSfGwiSz2_gq6NHo3MGyJyH4_GKv_TcY1YmbwkctKlCh5aVToA/viewform?usp=sf_link) to be considered for membership.
+This section introduces the key concepts behind drand. For information about consuming randomness from a drand network, see the [**Developer's Guide**](../03_dev-guide/03-00-Getting-started-devs). For help running a drand network, see the entries under the “For Operators” section. To run node(s) or relay(s) for the [League of Entropy](https://leagueofentropy.org), please [apply to the League](https://docs.google.com/forms/d/e/1FAIpQLSfGwiSz2_gq6NHo3MGyJyH4_GKv_TcY1YmbwkctKlCh5aVToA/viewform?usp=sf_link) to be considered for membership.
 
-- Read the [**What is "drand"?**](../about/1-0-about) section to learn more about drand’s main goals.  It gives an overview of the challenges drand aims to address.
-- [**Cryptography**](2-1-concepts-cryptography) provides an overview of the cryptographic building blocks that drand uses to generate publicly-verifiable, unbiased, and unpredictable randomness in a distributed manner.
-- [**Security Model**](2-2-concepts-security-model) describes the security considerations taken into account when designing and building drand.
-- [**Specification**](2-3-concepts-specification) is a formal description of the drand protocols.
-- [**Timelock Encryption**](2-4-concepts-timelock-encryption) gives all the information on our Timelock Encryption scheme, and links on where to find the tools to use it.
+- Read the [**What is "drand"?**](../01_about/01-00-drand-explained) section to learn more about drand’s main goals.  It gives an overview of the challenges drand aims to address.
+- [**Cryptography**](../02_concepts/02-01-Cryptography.md) provides an overview of the cryptographic building blocks that drand uses to generate publicly-verifiable, unbiased, and unpredictable randomness in a distributed manner.
+- [**Security Model**](../02_concepts/02-02-Security_Model.md) describes the security considerations taken into account when designing and building drand.
+- [**Specification**](../02_concepts/02-03-Specification.md) is a formal description of the drand protocols.
+- [**Timelock Encryption**](../02_concepts/02-04-Timelock_Encryption.md) gives all the information on our Timelock Encryption scheme, and links on where to find the tools to use it.
 
 ---


### PR DESCRIPTION
### Summary
This pull request addresses the issue of broken links found in the documentation. 

### Changes Made
- Updated links in the `02-00-Intro-to-drand.md` file to ensure they point to the correct resources.
- Verified that all links are functional and lead to the intended destinations.