### PR TITLE
feat: improve readability of docs

### DIFF
--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -6,7 +6,7 @@ import DrandLogo from "./img/drand-logo.png";
 
 # Welcome to the drand docs 🎲!
 
-<img src={DrandLogo} />
+<img src={DrandLogo} style={{ width: '150px', height: 'auto' }} />
 
 Use this documentation to add secure, high-entropy, verifiable randomness to your application.
 
@@ -20,7 +20,3 @@ This is the documentation site for drand including both general and developer do
 - [4.0 Operators Guide](category/40-operators-guide) | A guide for drand node operators.
 - [5.0 drand Community](category/50-drand-community) | Ways you can connect with the drand community.
 - [6.0 drand FAQ](category/60-drand-faq) | Frequently asked questions about drand and their answers.
-
-
-
-

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,15 @@ import styles from './index.module.css';
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
+    <header >
+      <div style={{width: "100%", maxHeight: '500px', overflow: "hidden"}}>
+      <img
+        src="/img/banner.avif"  // Path to your banner image
+        alt="Banner"
+        style={{width: "100%", height: '100%', objectFit: "cover", objectPosition: "center bottom"}}
+      />
+    </div>
+    <div className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
         <Heading as="h1" className="hero__title">
           {siteConfig.title}
@@ -24,6 +32,7 @@ function HomepageHeader() {
           </Link>
         </div>
       </div>
+    </div>
     </header>
   );
 }

--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -7,14 +7,6 @@ export default function Layout(props) {
   const {siteConfig} = useDocusaurusContext();
   return (
     <OriginalLayout {...props}>
-      {/* Add your banner image below the navbar */}
-      <div style={{width: "100%", maxHeight: '500px', overflow: "hidden"}}>
-        <img
-          src="/img/banner.avif"  // Path to your banner image
-          alt="Banner"
-          style={{width: "100%", height: '100%', objectFit: "cover", objectPosition: "center bottom"}}
-        />
-      </div>
       {props.children}
     </OriginalLayout>
   );


### PR DESCRIPTION
While adding openAPI documentation, found pretty annoying when navigating the docs because of the big banner and logo. Every time after navigating, i will need to scroll down half of my screen since the top half is occupied by the banner and the logo when the user first loaded into docs.

So following changes are recommended.
- Removed the large banner image from the home page
- Resized the DrandLogo to a smaller size to prevent it from occupying the whole screen

Before:
![Screenshot 2025-03-09 at 21 46 09](https://github.com/user-attachments/assets/3901c6b7-e394-4dd6-8ef4-16f6b9a26659)
![Screenshot 2025-03-09 at 21 46 15](https://github.com/user-attachments/assets/e7635478-07c5-4af3-90a9-6f4b659c3e41)

After:
![Screenshot 2025-03-09 at 21 42 00](https://github.com/user-attachments/assets/165af912-2b9d-4e8d-9ea6-50007c6bc27a)
